### PR TITLE
Config : Change AuthenticationMethod to External

### DIFF
--- a/conf/config.xml
+++ b/conf/config.xml
@@ -6,7 +6,7 @@
   <UrlBase>__PATH__</UrlBase>
   <BindAddress>127.0.0.1</BindAddress>
   <ApiKey>__API_KEY__</ApiKey>
-  <AuthenticationMethod>None</AuthenticationMethod>
+  <AuthenticationMethod>External</AuthenticationMethod>
   <UpdateMechanism>BuiltIn</UpdateMechanism>
   <Branch>develop</Branch>
 </Config>


### PR DESCRIPTION
## Problem

- Current AuthenticationMethod  value no longer allow to disable authentication (since at least [1.1.0.2322](https://github.com/Prowlarr/Prowlarr/releases/tag/v1.1.0.2322)  (`To prevent remote access without authentication, Prowlarr now requires authentication to be enabled. Configure your authentication method and credentials. You can optionally disable authentication from local addresses. Refer to the FAQ for additional information`)

## Solution

- to remain consistent with the current authentication flow. (that rely on ssowat), the default value should be *Externa*l (see. https://wiki.servarr.com/prowlarr/faq#can-i-disable-forced-authentication)

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
