### PR TITLE
Upgrade to v1.31.2.4975

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It shall NOT be edited by hand.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Shipped version:** 1.30.2.4939~ynh1
+**Shipped version:** 1.31.2.4975~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -20,7 +20,7 @@ No se debe editar a mano.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Versión actual:** 1.30.2.4939~ynh1
+**Versión actual:** 1.31.2.4975~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -20,7 +20,7 @@ EZ editatu eskuz.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Paketatutako bertsioa:** 1.30.2.4939~ynh1
+**Paketatutako bertsioa:** 1.31.2.4975~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Version incluse :** 1.30.2.4939~ynh1
+**Version incluse :** 1.31.2.4975~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -20,7 +20,7 @@ NON debe editarse manualmente.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Versión proporcionada:** 1.30.2.4939~ynh1
+**Versión proporcionada:** 1.31.2.4975~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -20,7 +20,7 @@ Ini TIDAK boleh diedit dengan tangan.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Versi terkirim:** 1.30.2.4939~ynh1
+**Versi terkirim:** 1.31.2.4975~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -20,7 +20,7 @@ Hij mag NIET handmatig aangepast worden.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Geleverde versie:** 1.30.2.4939~ynh1
+**Geleverde versie:** 1.31.2.4975~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -20,7 +20,7 @@ Nie powinno być ono edytowane ręcznie.
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Dostarczona wersja:** 1.30.2.4939~ynh1
+**Dostarczona wersja:** 1.31.2.4975~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -20,7 +20,7 @@
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**Поставляемая версия:** 1.30.2.4939~ynh1
+**Поставляемая версия:** 1.31.2.4975~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -20,7 +20,7 @@
 
 Complete management of your indexers for Radarr, Sonarr, Lidarr...
 
-**分发版本：** 1.30.2.4939~ynh1
+**分发版本：** 1.31.2.4975~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Prowlarr"
 description.en = "Complete management of your indexers for Radarr, Sonarr, Lidarr..."
 description.fr = "Gestion complète de vos indexeurs pour Radarr, Sonarr, Lidarr..."
 
-version = "1.30.2.4939~ynh1"
+version = "1.31.2.4975~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -43,13 +43,13 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://github.com/Prowlarr/Prowlarr/releases/download/v1.30.2.4939/Prowlarr.master.1.30.2.4939.linux-core-x64.tar.gz"
-    amd64.sha256 = "6a21f86efe3b72707352d1707c97e6ad8fb62daaa06644574f6271f059125fb3"
+    amd64.url = "https://github.com/Prowlarr/Prowlarr/releases/download/v1.31.2.4975/Prowlarr.master.1.31.2.4975.linux-core-x64.tar.gz"
+    amd64.sha256 = "ec729fe4f9f43d4a3734f31d11caf0f5d665e04264adc862da4f63b5faa25e58"
 
-    arm64.url = "https://github.com/Prowlarr/Prowlarr/releases/download/v1.30.2.4939/Prowlarr.master.1.30.2.4939.linux-core-arm64.tar.gz"
-    arm64.sha256 = "8b38797abdee2d4285323502899601aad4bdb28b227120a8faabdabdc9d7ffab"
-    armhf.url = "https://github.com/Prowlarr/Prowlarr/releases/download/v1.30.2.4939/Prowlarr.master.1.30.2.4939.linux-core-arm.tar.gz"
-    armhf.sha256 = "8e691c9e9026c4a2aec158340121ef6dab3572c498187b306ff939649b539c65"
+    arm64.url = "https://github.com/Prowlarr/Prowlarr/releases/download/v1.31.2.4975/Prowlarr.master.1.31.2.4975.linux-core-arm64.tar.gz"
+    arm64.sha256 = "4091c94043f938180ca4274ec5444ff7cf9eea630170d4c061208e44a9c55e9c"
+    armhf.url = "https://github.com/Prowlarr/Prowlarr/releases/download/v1.31.2.4975/Prowlarr.master.1.31.2.4975.linux-core-arm.tar.gz"
+    armhf.sha256 = "c2c30f891d2f2bda71db482e4c9e50f59968aee42f5b55271735b885a07fbbf8"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.amd64 = "^Prowlarr\\.master\\..*\\.linux-core-x64\\.tar\\.gz$"

--- a/tests.toml
+++ b/tests.toml
@@ -3,3 +3,17 @@
 test_format = 1.0
 
 [default]
+
+    # ------------
+    # Tests to run
+    # ------------
+
+    # -------------------------------
+    # Default args to use for install
+    # -------------------------------
+
+    # -------------------------------
+    # Commits to test upgrade from
+    # -------------------------------
+
+    test_upgrade_from.b30b84729f8591d4663de390541334c4285cb7f3.name = "Upgrade from 1.30.2.4939~ynh1"


### PR DESCRIPTION
Upgrade sources
- `main` v1.31.2.4975: https://github.com/Prowlarr/Prowlarr/releases/tag/v1.31.2.4975

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
